### PR TITLE
[FE FIX] Low stock page prune

### DIFF
--- a/client/src/models/tableColumns.ts
+++ b/client/src/models/tableColumns.ts
@@ -116,21 +116,21 @@ export const lowStockColumns: Column[] = [
     size: "small",
     center: false,
   },
-  {
-    title: "Measure",
-    size: "medium",
-    center: false,
-    customComponent: columnCustomComponents.pill,
-  },
-  {
-    title: "Item",
-    size: "small",
-    center: true,
-    customComponent: columnCustomComponents.pill,
-  },
-  { title: "Ages", size: "small", center: true },
-  { title: "Acronym", size: "small", center: true },
-  { title: "Level", size: "xs", center: true },
+  // {
+  //   title: "Measure",
+  //   size: "medium",
+  //   center: false,
+  //   customComponent: columnCustomComponents.pill,
+  // },
+  // {
+  //   title: "Item",
+  //   size: "small",
+  //   center: true,
+  //   customComponent: columnCustomComponents.pill,
+  // },
+  // { title: "Ages", size: "small", center: true },
+  // { title: "Acronym", size: "small", center: true },
+  // { title: "Level", size: "xs", center: true },
   { title: "Edition", size: "xs", center: true },
 ];
 // this one doesn't need checkboxes on the rows


### PR DESCRIPTION
### **FE FIX - low stock page prune headers**

**Testing**
1. navigate to branch: `git checkout low-stock-prune-headers`
2. `cd` to the `public` folder
3. run `npm install`
4. run `npm start`
5. ensure on the admin view, low stock page only has the required headers.
<br>

For reference checkout issue: #110 