### PR TITLE
[FE FIX] Prune columns after "Measure" on signed-out and overdue pages

### DIFF
--- a/client/src/models/tableColumns.ts
+++ b/client/src/models/tableColumns.ts
@@ -58,15 +58,15 @@ export const signedOutColums: Column[] = [
     center: false,
     customComponent: columnCustomComponents.pill,
   },
-  {
-    title: "Item",
-    size: "small",
-    center: true,
-    customComponent: columnCustomComponents.pill,
-  },
-  { title: "Ages", size: "small", center: true },
-  { title: "Level", size: "xs", center: true },
-  { title: "Edition", size: "xs", center: true },
+  // {
+  //   title: "Item",
+  //   size: "small",
+  //   center: true,
+  //   customComponent: columnCustomComponents.pill,
+  // },
+  // { title: "Ages", size: "small", center: true },
+  // { title: "Level", size: "xs", center: true },
+  // { title: "Edition", size: "xs", center: true },
 ];
 
 export const overdueColumns: Column[] = [
@@ -91,15 +91,15 @@ export const overdueColumns: Column[] = [
     center: false,
     customComponent: columnCustomComponents.pill,
   },
-  {
-    title: "Item",
-    size: "small",
-    center: true,
-    customComponent: columnCustomComponents.pill,
-  },
-  { title: "Ages", size: "small", center: true },
-  { title: "Level", size: "xs", center: true },
-  { title: "Edition", size: "xs", center: true },
+  // {
+  //   title: "Item",
+  //   size: "small",
+  //   center: true,
+  //   customComponent: columnCustomComponents.pill,
+  // },
+  // { title: "Ages", size: "small", center: true },
+  // { title: "Level", size: "xs", center: true },
+  // { title: "Edition", size: "xs", center: true },
 ];
 
 export const lowStockColumns: Column[] = [


### PR DESCRIPTION
### **FE FIX - prune headers for signed-out and overdue pages**

**Testing**
1. navigate to branch: `git checkout prune-pages`
2. `cd` to the `public` folder
3. run `npm install`
4. run `npm start`
5. ensure the both the signed-out and overdue pages the headers are pruned.
<br>

For reference checkout issue: #105 