### PR TITLE
FE Notes in Table and Add & Edit Modals

### DIFF
--- a/client/src/components/FormItem.tsx
+++ b/client/src/components/FormItem.tsx
@@ -5,6 +5,7 @@ import { itemTypeOptions } from "../models/libraryItem";
 import { MdOutlineRemoveCircleOutline } from "react-icons/md";
 import { Item } from "../models/BEModels";
 import uuid from "react-uuid";
+import { Switch } from "@mui/material";
 
 interface FormItemProps {
   onRemove: (id: string) => void;
@@ -20,7 +21,7 @@ const FormItem: React.FC<FormItemProps> = ({
   onChange = (item: Partial<Item> & { ID: string }) => {},
 }: FormItemProps) => {
   const [itemData, setItemData] = useState<Partial<Item> & { ID: string }>(
-    item ? item : { ID: uuid() }
+    item ? item : { ID: uuid()}
   );
   useEffect(() => {
     console.log("item changed!");
@@ -82,7 +83,7 @@ const FormItem: React.FC<FormItemProps> = ({
             />
           </div>
         </div>
-        <div className="pt-4 pb-6">
+        <div className="pt-4">
           <InputField
             placeholder={item ? item.Location : "Location that item is stored."}
             value={itemData.Location ? itemData.Location : ""}
@@ -94,6 +95,26 @@ const FormItem: React.FC<FormItemProps> = ({
             }
           />
         </div>
+        <div className="pt-4 pb-6 flex items-center">
+            <div className="m-0">
+              {/* NOTE: should show or hide the additional notes on the table depending if on or off */}
+              <Switch />
+            </div>
+            <div className="ml-0 w-full text-wrap">
+              <InputField
+                placeholder={
+                  item ? item.Notes : "Any additional notes about the item"
+                }
+                value={itemData.Notes ? itemData.Notes : ""}
+                label="Additional Notes"
+                type="Text"
+                important={false}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setItemData({ ...itemData, Notes: e.target.value })
+                }
+              />
+            </div>
+          </div>
       </div>
     </div>
   );

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -15,8 +15,8 @@ const Navbar = (props: { userType: Role }) => {
     props.userType === "admin" ? adminMenuOptions : clientMenuOptions;
 
   return (
-    <div className="h-[95%] w-[7rem] rounded-3xl bg-gray-100 pb-4 flex flex-col items-center">
-      <img src={clinicLogo} alt="clinic logo" className="mt-4"></img>
+    <div className="h-[98%] w-[7rem] rounded-3xl bg-gray-100 pb-4 flex flex-col items-center">
+      <img src={clinicLogo} alt="clinic logo" className="mt-2"></img>
       <div
         className={`flex flex-col w-full justify-between items-center self-center justify-self-center mb-auto ${
           props.userType === "admin" ? "h-1/2 mt-[4vh]" : "h-1/3 mt-[20vh]"
@@ -26,7 +26,7 @@ const Navbar = (props: { userType: Role }) => {
           return (
             <Link to={option.url} className="w-full" key={uuid()}>
               <span
-                className={`w-[93%] flex items-center flex-col justify-center p-4 pr-1 rounded-full cursor-pointer transition-all	 ${
+                className={`w-[93%] flex items-center flex-col justify-center p-3 pr-1 rounded-full cursor-pointer transition-all	 ${
                   selected === option.page ? "bg-white px-1" : null
                 }`}
                 onClick={() => setSelected(option.page)}

--- a/client/src/components/Table.tsx
+++ b/client/src/components/Table.tsx
@@ -325,6 +325,11 @@ const Table = (props: {
                                 <div className="pl-10">
                                   <p>{item.ItemName}</p>
                                 </div>
+                                {item.Notes && (
+                                  <div className="pl-10 italic">
+                                    <p>{`Notes: ${item.Notes}`}</p>
+                                  </div>
+                                )}
                               </div>
                             ))}
                           </div>

--- a/client/src/models/BEModels.ts
+++ b/client/src/models/BEModels.ts
@@ -19,6 +19,7 @@ export interface Item {
   Status: Boolean;
   Stock: number;
   TestID: string;
+  Notes: string;
 }
 
 export interface SignedOutItem {


### PR DESCRIPTION
- [ ] #218 
- [ ] #224 


Next: Needs hooking up to BE. There is a toggle in the Add and Edit modals which should hide or show the corresponding notes for the item in the expanded part of the table.