### PR TITLE
Check user confirmed sign in

### DIFF
--- a/app/resources/user.py
+++ b/app/resources/user.py
@@ -126,11 +126,13 @@ class User(Resource):
         if request.method == "OPTIONS":  # CORS preflight
             return _build_cors_preflight_response()
         try:
-            id_hash = _select_cols_one({"Email": email}, ["ID", "Hash"])
-            if verify_password(id_hash["Hash"], password):
-                return _select_one({'ID': id_hash['ID']}), 200
-            abort(401)
-        except KeyError as e:
+            user = _select_cols_one({"Email": email}, ["ID", "Hash", "IsAccepted"])
+            if not verify_password(user["Hash"], password):
+                abort(401)
+            if not user['IsAccepted']:
+                abort(403)
+            return _select_one({'ID': user['ID']}), 200
+        except KeyError:
             abort(404, message="Email does not exist.")
 
     def delete(self, email, password):

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -56,7 +56,11 @@ function App({ page }: AppProps) {
 
   async function handleSignIn(email: string, password: string) {
     const user = await authenticateAccount(email, password).catch((e) => {
-      alert("Email or password is incorrect");
+      if (e.message == "Account not confirmed") {
+        alert("Sorry, your account has not been confirmed by the clinic Administrator yet.")
+      } else {
+        alert("Email or password is incorrect");
+      }
       window.location.reload();
     });
     if (user) {

--- a/client/src/services/UserService.ts
+++ b/client/src/services/UserService.ts
@@ -88,9 +88,11 @@ export async function authenticateAccount(email: string, password: string) {
       const axiosError: AxiosError = error;
       if (axiosError.response) {
         // Server responded with an error status code (4xx or 5xx)
-
-        if (axiosError.response.status === 400) {
+        if (axiosError.response.status === 401) {
           throw new InvalidEntry("Incorrect Password.");
+        }
+        else if (axiosError.response.status === 403) {
+          throw new InvalidEntry("Account not confirmed");
         }
       } else if (axiosError.request) {
         // No response received


### PR DESCRIPTION
Ensures that a user must be confirmed before signing in.

#### Testing

1. Create a new account, then try and sign in (you should get an error saying that your account is not confirmed)
2. Go onto adminer (`localhost:8080`) and edit your account so that `IsConfirmed` is `1`
3. Sign in again (it should work now!)
4. Sign-out then try and sign-in with an incorrect password (you should get a *different* error, saying you have an incorrect email/password)